### PR TITLE
Make sure we dont truncate after hosts

### DIFF
--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
         {{- if .Values.lenses.zookeepers.chroot }}
         - name: LENSES_ZOOKEEPER_CHROOT
           value: {{ .Values.lenses.zookeepers.chroot | quote }}
-        {{- end -}}
+        {{- end }}
 
         - name: LENSES_SCHEMA_REGISTRY_URLS
           value: |-


### PR DESCRIPTION
With the additional "-" character we end up with out put 

```
        - name: LENSES_ZOOKEEPER_HOSTS
          value: |-
            [
              {"url":"kafka-cp-helm-cp-zookeeper:2181", "jmx":"kafka-cp-helm-cp-zookeeper:9585"}
            ]- **name: LENSES_SCHEMA_REGISTRY_URLS**
          value: |-
            [
              {"url":"http://kafka-cp-helm-cp-schema-registry:8081", "jmx":"kafka-cp-helm-cp-schema-registry:9582"}
            ]
```
which is not desired